### PR TITLE
Render without union

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@jscad/io": "2.0.0-alpha.1",
-    "@jscad/io-utils": "^0.1.3",
-    "@jscad/json-deserializer": "2.0.0-alpha.5",
-    "@jscad/json-serializer":"2.0.0-alpha.5",
-    "@jscad/modeling": "2.0.0-alpha.1",
-    "@jscad/utils": "2.0.0-alpha.1",
+    "@jscad/modeling": "^2.0.0-alpha.5",
+    "@jscad/regl-renderer": "^2.0.0-alpha.7",
     "@webpack-cli/init": "^0.2.2",
     "workerpool": "^6.0.0"
   },

--- a/src/worker.js
+++ b/src/worker.js
@@ -232,8 +232,7 @@ function stl(values){
 
 function render(shape){
     try{
-        const unionized = union(shape.map(x => x.geometry))  //Union to compress it all into one
-        var solids = entitiesFromSolids({}, unionized)  //This should be able to handle an array but right now it can't
+        var solids = entitiesFromSolids({}, shape.map(x => x.geometry))
     }
     catch(err){
         console.log(err)

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,5 +1,6 @@
 const jscad = require('@jscad/modeling')
-const stlSerializer = require('@jscad/stl-serializer')
+const { entitiesFromSolids } = require('@jscad/regl-renderer') 
+// const stlSerializer = require('@jscad/stl-serializer')
 
 
 const workerpool = require('workerpool');
@@ -223,9 +224,21 @@ function clr(values){
 
 function stl(values){
     
-    const rawData = stlSerializer.serialize({binary: false},values[0].geometry)
+    //const rawData = stlSerializer.serialize({binary: false},values[0].geometry)
     
-    return rawData
+    return values[0]//rawData
+}
+
+function render(shape){
+    try{
+        const unionized = union(shape.map(x => x.geometry))  //Union to compress it all into one
+        var solids = entitiesFromSolids({}, unionized)  //This should be able to handle an array but right now it can't
+    }
+    catch(err){
+        console.log(err)
+    }
+    
+    return solids
 }
 
 
@@ -239,6 +252,7 @@ workerpool.worker({
     intersection:intersection,
     hull:wrap,
     specify: specify,
+    render:render,
     stl:stl,
     tag, tag,
     color: clr,

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,6 +1,6 @@
 const jscad = require('@jscad/modeling')
 const { entitiesFromSolids } = require('@jscad/regl-renderer') 
-// const stlSerializer = require('@jscad/stl-serializer')
+const stlSerializer = require('@jscad/stl-serializer')
 
 
 const workerpool = require('workerpool');
@@ -223,10 +223,11 @@ function clr(values){
 }
 
 function stl(values){
+    const unionized = union(values[0].map(x => x.geometry))  //Union to compress it all into one
     
-    //const rawData = stlSerializer.serialize({binary: false},values[0].geometry)
+    const rawData = stlSerializer.serialize({binary: false},unionized)
     
-    return values[0]//rawData
+    return rawData
 }
 
 function render(shape){


### PR DESCRIPTION
I was joining all the parts in an assembly together to display them all, but I asked in the jscad forums and it turns out that we could pass the render function an array of stuff to display so that's what this does.