### PR TITLE
Replace extrusions with Cylinider and Cuboid where possible 

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -47,14 +47,12 @@ function extr(values){
         var extrudedObj
         if(item.circle){
             //Create a cylinder instead of an extrusion to avoid issues with extrude
-            console.log("Circle seen")
             const bounds = measureBoundingBox(item.geometry)
             const x = (bounds[1][0] - bounds[0][0])/2 + bounds[0][0]
             const y = (bounds[1][1] - bounds[0][1])/2 + bounds[0][1]
             extrudedObj = cylinder({center:[x,y,values[1]/2], height: values[1], radius: item.circle.radius, segments: item.circle.segments})
         }
         else if(item.rectangle){
-            console.log("Rectangle seen")
             const bounds = measureBoundingBox(item.geometry)
             const x = (bounds[1][0] - bounds[0][0])/2 + bounds[0][0]
             const y = (bounds[1][1] - bounds[0][1])/2 + bounds[0][1]
@@ -63,8 +61,7 @@ function extr(values){
             extrudedObj = cuboid({center:[x,y,values[1]/2], size: size})
         }
         else{
-            console.log("Third option seen")
-            const extrudedObj = extrudeLinear({height: values[1]}, item.geometry)
+            extrudedObj = extrudeLinear({height: values[1]}, item.geometry)
         }
         extrudedArray.push({geometry: extrudedObj, tags: item.tags, color: item.color})
     })
@@ -74,8 +71,8 @@ function extr(values){
 function rotat(values){
     var rotatedArray = []
     values[0].forEach(item => {
-        const rotatedObj = rotate([3.1415*values[1]/180,3.1415*values[2]/180,3.1415*values[3]/180], item.geometry)
-        rotatedArray.push({geometry: rotatedObj, tags: item.tags, color: item.color})
+        item.geometry =  rotate([3.1415*values[1]/180,3.1415*values[2]/180,3.1415*values[3]/180], item.geometry)
+        rotatedArray.push(item)
     })
 	return rotatedArray
 }

--- a/src/worker.js
+++ b/src/worker.js
@@ -32,18 +32,32 @@ const { extrudeLinear, extrudeRectangular, extrudeRotate } = require('@jscad/mod
 
 function circ(values){
 	var myCircle = circle({ radius: values[0]/2, segments: values[1]})
-	return [{geometry: myCircle, tags: [], color: "pink"}]
+	return [{geometry: myCircle, tags: [], color: "pink", circle: {radius: values[0]/2, segments: values[1]}}]
 }
 
 function rect(values){
 	var myCube = rectangle({size: values})
-	return [{geometry: myCube, tags: [], color: "pink"}]
+	return [{geometry: myCube, tags: [], color: "pink", rectangle: {size: values}}]
 }
 
 function extr(values){
     var extrudedArray = []
     values[0].forEach(item => {
-        const extrudedObj = extrudeLinear({height: values[1]}, item.geometry)
+        var extrudedObj
+        if(item.circle){
+            //Create a cylinder instead of an extrusion to avoid issues with extrude
+            console.log("Circle seen")
+            extrudedObj = cylinder({height: values[1], radius: item.circle.radius, segments: item.circle.segments})
+        }
+        if(item.rectangle){
+            console.log("Rectangle seen")
+            var size = item.rectangle.size
+            size.push(values[1])
+            extrudedObj = cuboid({size: size})
+        }
+        else{
+            const extrudedObj = extrudeLinear({height: values[1]}, item.geometry)
+        }
         extrudedArray.push({geometry: extrudedObj, tags: item.tags, color: item.color})
     })
 	return extrudedArray
@@ -198,6 +212,7 @@ function code(values){
     const returnedGeometry = foo({...inputs });
     
 	return [{geometry: returnedGeometry, tags: [], color: "pink"}]
+}
 
 
 //Just a placeholder for now

--- a/src/worker.js
+++ b/src/worker.js
@@ -45,14 +45,14 @@ function extr(values){
     var extrudedArray = []
     values[0].forEach(item => {
         var extrudedObj
-        if(item.circle){
+        if(item.circle && values[1] > 0){
             //Create a cylinder instead of an extrusion to avoid issues with extrude
             const bounds = measureBoundingBox(item.geometry)
             const x = (bounds[1][0] - bounds[0][0])/2 + bounds[0][0]
             const y = (bounds[1][1] - bounds[0][1])/2 + bounds[0][1]
             extrudedObj = cylinder({center:[x,y,values[1]/2], height: values[1], radius: item.circle.radius, segments: item.circle.segments})
         }
-        else if(item.rectangle){
+        else if(item.rectangle && values[1] > 0){
             const bounds = measureBoundingBox(item.geometry)
             const x = (bounds[1][0] - bounds[0][0])/2 + bounds[0][0]
             const y = (bounds[1][1] - bounds[0][1])/2 + bounds[0][1]


### PR DESCRIPTION
This pull request replaces extrusions of circles and squares with cylinders and cuboids where possible as a work around for the fact that extrusions are currently producing bad geometry. Where the input to extrusion is not a circle or a square, the extrusion will be performed directly 